### PR TITLE
set config options inside `.config` method only

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,13 +122,14 @@ impl CatLoggr {
 	/// use cat_loggr::{CatLoggr, LogLevel, LoggrConfig};
 	/// let mut logger = CatLoggr::new(None);
 	/// 
-	/// logger.config(LoggrConfig {
+	/// logger.config(Some(LoggrConfig {
 	/// 	levels: Some(vec![
 	/// 		LogLevel   { name: "fatal".to_string(), style: owo_colors::Style::new().red().on_black(), position: None },
 	/// 		LogLevel   { name: "info".to_string(), style: owo_colors::Style::new().red().on_black(), position: None }	
 	/// 	]),
+	///		color_enabled: false,
 	/// 	..LoggrConfig::default()
-	/// });
+	/// }));
 	/// ```
 	pub fn config(&mut self, options: Option<LoggrConfig>) -> &mut Self {
 		let options = options.unwrap_or_default();		

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,9 @@ impl CatLoggr {
 	/// 	..LoggrConfig::default()
 	/// });
 	/// ```
-	pub fn config(&mut self, options: LoggrConfig) -> &mut Self {
+	pub fn config(&mut self, options: Option<LoggrConfig>) -> &mut Self {
+		let options = options.unwrap_or_default();		
+
 		if options.timestamp_format.is_some() {
 			self.timestamp_format = options.timestamp_format.unwrap();
 		}
@@ -183,12 +185,7 @@ impl CatLoggr {
 	/// ```
 	pub fn new(options: Option<LoggrConfig>) -> Self {
 		let mut logger = Self::default();
-
-		if options.is_some() {
-			logger.config(options.unwrap());
-		} else {
-			logger.config(LoggrConfig::default());	
-		}
+		logger.config(options);	
 
 		logger
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,8 @@ impl CatLoggr {
 
 		if options.levels.is_some() {
 			self.set_levels(options.levels.unwrap());
+		} else {
+			self.set_levels(Self::get_default_levels());	
 		}
 
 		if options.level.is_some() {
@@ -182,14 +184,11 @@ impl CatLoggr {
 	pub fn new(options: Option<LoggrConfig>) -> Self {
 		let mut logger = Self::default();
 
-		logger.set_levels(Self::get_default_levels());
-
 		if options.is_some() {
 			logger.config(options.unwrap());
 		} else {
-			logger.level_name = Some(top::<LogLevel>(&mut logger.levels).unwrap().name);
+			logger.config(LoggrConfig::default());	
 		}
-
 
 		logger
 	}

--- a/src/loggr_config.rs
+++ b/src/loggr_config.rs
@@ -14,6 +14,7 @@ pub struct LoggrConfig {
 	/// Custom level definitions
 	pub levels: Option<Vec<LogLevel>>,
 
+	/// Use colors when outputting
 	pub color_enabled: bool,
 }
 


### PR DESCRIPTION
### Changes
- Call `.config` method instead of setting configs inside `.new` method

fixes #4 